### PR TITLE
Add endpoints for password reset

### DIFF
--- a/index.html
+++ b/index.html
@@ -154,13 +154,25 @@
 
       /* Send password reset link 
             payload = {email_address: "john@example.com"} */
-      Password.sendResetLink = function(payload) {
+      Password.email = function(payload) {
         fetch('/api/password/email', make(payload))
           .then(promise => promise.json())
           .then(json => {
             console.log(json);
           });
       }
+
+      /* Reset password using a given token
+            payload: {password: 'secret', password_confirmation: 'secret'} */
+      Password.reset = function(payload) {
+        fetch(`/api/password/reset/${window.reset_token.value}`, make(payload))
+          .then(promise => promise.json())
+          .then(json => {
+            console.log(json);
+          });
+      }
+
+
 
       // Because this is <script type = "module", to make User object
       // globally available so it can be used in HTML attribute events,
@@ -232,8 +244,15 @@
         /><br />
         <input
           type="button"
-          onclick="Password.sendResetLink({email_address: window.email_address.value})"
+          onclick="Password.email({email_address: window.email_address.value})"
           value="send password reset link"
+        /><br />
+
+        <input type="text" id="reset_token" placeholder="reset token">
+        <input
+          type="button"
+          onclick="Password.reset({password: 'secret', password_confirmation: 'secret'})"
+          value="reset password"
         /><br />
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -9,6 +9,10 @@
         constructor() {}
       }
 
+      class Password {
+        constructor() {}
+      }
+
       // Create payload -- redundant everywhere, now in neat make() function
       let make = function(payload) {
         return {
@@ -148,11 +152,22 @@
           });
       };
 
+      /* Send password reset link 
+            payload = {email_address: "john@example.com"} */
+      Password.sendResetLink = function(payload) {
+        fetch('/api/password/email', make(payload))
+          .then(promise => promise.json())
+          .then(json => {
+            console.log(json);
+          });
+      }
+
       // Because this is <script type = "module", to make User object
       // globally available so it can be used in HTML attribute events,
       // we have to manually add it to window object
       window.onload = () => {
         window.User = User;
+        window.Password = Password;
       };
     </script>
     <style type="text/css">
@@ -214,6 +229,11 @@
           type="button"
           onclick="User.like({id:{user:1, tweet:1}})"
           value="like tweet id=1 by user id=1"
+        /><br />
+        <input
+          type="button"
+          onclick="Password.sendResetLink({email_address: window.email_address.value})"
+          value="send password reset link"
         /><br />
       </div>
     </div>

--- a/module/api/api.js
+++ b/module/api/api.js
@@ -314,12 +314,11 @@ function action_send_reset_link(request, payload) {
                 if (results.length === 0)
                     resolve(`{"success": false, "message": "We couldn't find your account with that information"}`);
                 else {
-
-                   database.connection.query(`INSERT INTO password_resets (user_id, token, expiry_date) VALUES (${results[0].id}, "${md5(payload.email_address)}", DATE_ADD(CURRENT_TIMESTAMP(), INTERVAL 30 MINUTE))`, function(error,results) {
+                   database.connection.query(`INSERT INTO password_resets VALUES ("${payload.email_address}", "${md5(payload.email_address)}", DATE_ADD(CURRENT_TIMESTAMP(), INTERVAL 30 MINUTE))`, function(error) {
                         if(error) throw error;
                         console.log("Token created"); 
+                        resolve(`{"success": true, "message": "Password reset link has been sent to ${payload.email_address}"}`);
                    });
-                   resolve(`{"success": true, "message": "Password reset link has been sent to ${payload.email_address}", "reset_link": ""}`);
                 }
             });
     }).catch((error) => { console.log(error) });


### PR DESCRIPTION
Password reset is one of the essential functionalities of a web app and this project is no exception. Discussion and research done to make this change and it is WIP. However the password reset endpoints have basic behaviour to test.

## What changes does this PR make?
Two new endpoints are registered in `api.js` and to test endpoints buttons and input was created in `index.html`. To prevent `user` table from bloating, endpoints use new table([shown below section](#how-to-make-these-endpoints-work?)) for the password reset functionality

## How to test these endpoints?
First of all, the password reset functionality requires new `password_resets` table. Run the following query to create it:

```sql
CREATE TABLE password_resets (
    email_address VARCHAR(255) NOT NULL, 
    token TEXT NOT NULL,
    expiry_date TIMESTAMP NOT NULL,
    INDEX email (email_address)
)
````
And now the feature is fully functional! Next step is entering email address in email field and click *send password reset link* button.

> Sending reset link via email is not functional right now. Instead, the endpoint will create reset token in the database

To test reset functionality, copy recently created reset token from `password_resets` table then paste it into token field then hit *reset password* button to change old password to `password`!

You can change payload values in `index.html`.