### PR TITLE
Enabling a command line or environment switch for connection port

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ process.env.node_env = "localhost";
 
 // replace xx.xx.xx.xxx with your own remote IP address or localhost (127.0.0.1)
 const ip = '127.0.0.1'; // const ip = 'xx.xx.xx.xxx';
-const port = process.env.node_env === 'production' ? 80 : 3000;
+const port = process.env.PORT || (process.env.node_env === 'production' ? 80 : 3000);
 
 http.createServer(function(request, response) {
 


### PR DESCRIPTION
If you have multiple development systems using standard ports - this will allow you to easily change the connection port either by setting an environment variable 'PORT' or including the variable when starting the server.