### PR TITLE
Fix API response handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,22 +35,27 @@ http.createServer(function(request, response) {
     fs.readFile(filename, function (error, content) {
         if (error) {
             if (error.code == 'ENOENT') {
-                if (API.catchAPIrequest( request.url ))
+                if (API.catchAPIrequest( request.url )) {
+                    console.log("API request detecting...");
+
                     API.exec(request, response);
-                else
+                } else {
                     fs.readFile('./404.html', function (error, content) {
                         response.writeHead(200, { 'Content-Type': contentType });
                         response.end(content, 'utf-8');
                     });
+                }
             } else {
               response.writeHead(500)
               response.end('Server error: ' + error.code + ' ..\n');
               response.end();
             }
-        } 
-        console.log("API request detecting...");
-        response.writeHead(200, { 'Content-Type': contentType });
-        response.end(content, 'utf-8');
+        } else {
+            console.log("Returning a static file...");
+
+            response.writeHead(200, { 'Content-Type': contentType });
+            response.end(content, 'utf-8');
+        }
         
     });
 }).listen(port, ip);

--- a/module/api/api.js
+++ b/module/api/api.js
@@ -346,9 +346,9 @@ function identify(a, b) {
 // General use respond function -- send json object back to the browser in response to a request
 function respond(response, content) {
 	console.log("responding = ", [content]);
-	const jsontype = "{ 'Content-Type': 'application/json' }";
-	response.writeHead(200, jsontype);
-	response.end(content, 'utf-8');
+ 
+	response.writeHead(200, { 'Content-Type': 'application/json; charset=utf-8' });
+	response.end(content);
 }
 
 // Convert buffer to JSON object


### PR DESCRIPTION
All responses from the API were getting their content type changed to 'application/octet-stream' because the structure of index.js was changing the content type for every request after it had already been set (to whatever it was supposed to be). Slightly re-arranged the code so that real data returned from fs.readFile was only sent when there was not an error.

Changed the respond function of api.js to combine the content type and character set assignment into a single line.